### PR TITLE
Fix incorrect short form name

### DIFF
--- a/prototype-implementation/frontend/plain/yaml/src/org/jetbrains/amper/frontend/mutable-model.kt
+++ b/prototype-implementation/frontend/plain/yaml/src/org/jetbrains/amper/frontend/mutable-model.kt
@@ -456,7 +456,7 @@ internal fun List<FragmentBuilder>.handleSettings(config: YamlNode.Mapping): Res
         kover = KoverPartBuilder {
             it.getStringValue("kover")?.let {
                 enabled = when(it) {
-                    "true" -> true
+                    "enabled" -> true
                     else -> false
                 }
             }


### PR DESCRIPTION
This PR makes the short form name for kover consistent with the short form name of compose.