### PR TITLE
Add README + Download links for examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Try Amper with an example project
+
+We have prepared a number of example projects to help you explore Amper. You can check them out right here on GitHub, or download a zipped version to open in your IDE (refer to the [setup instructions](https://github.com/JetBrains/amper/blob/0.1/docs/Setup.md) if you need more information on how to get started.)
+
+| Example              | Download                                                                                                                 |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------|
+| Compose Android      | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/compose-android)      |
+| Compose Desktop      | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/compose-desktop)      |
+| Compose iOS          | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/compose-ios)          |
+| Coverage (Kover)     | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/coverage)             |
+| Gradle Interop       | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/gradle-interop)       |
+| Gradle Migration JVM | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/gradle-migration-jvm) |
+| Gradle Migration KMP | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/gradle-migration-kmp) |
+| JVM Hello World      | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/jvm-hello-world)      |
+| JVM Kotlin + Java    | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/jvm-kotlin%2bjava)    |
+| JVM with Tests       | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/jvm-with-tests)       |
+| Modularized          | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/modularized)          |
+| Multiplatform        | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/multiplatform)        |
+| New Project Template | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/new-project-template) |
+| Templates            | [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/templates)            |
+

--- a/examples/jvm-hello-world/README.md
+++ b/examples/jvm-hello-world/README.md
@@ -1,0 +1,3 @@
+# Amper example project ([download as ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/jvm-hello-world))
+
+Use this project as a jumping-off point for exploring Amper. Find instructions on how to get started in the [setup documentation](https://github.com/JetBrains/amper/blob/0.1/docs/Setup.md).


### PR DESCRIPTION
This PR adds a README to the `examples` directory. It includes download links for the individual example projects (via [`github-hoover`](https://github.com/SebastianAigner/github-hoover)). This allows people to download individual example projects with a single click, without having to clone the entire repository.

(We'll be adding the same kind of links in the `compose-multiplatform` repository soon as well – people rarely want to download _all_ example projects, they just want the one they can use to get started).

The PR also adds a brief README for JVM-Hello-World example since it is mentioned in the setup docs. This also makes following these instructions easier: the setup instructions direct users to the example, where they can directly download a [ZIP](https://hoover.fly.dev/download-zip/repo?user=JetBrains&name=amper&branch=0.1&path=/examples/jvm-hello-world) and open it in their IDE.