### PR TITLE
correct module layout for gradle desktop example

### DIFF
--- a/examples-gradle/compose-desktop/module.yaml
+++ b/examples-gradle/compose-desktop/module.yaml
@@ -9,4 +9,4 @@ settings:
   compose: enabled
 
 module:
-  layout: gradle-jvm
+  layout: default

--- a/examples-gradle/compose-desktop/module.yaml
+++ b/examples-gradle/compose-desktop/module.yaml
@@ -7,6 +7,3 @@ dependencies:
 
 settings:
   compose: enabled
-
-module:
-  layout: default


### PR DESCRIPTION
Currently the module-layout for the gradle example and compose-desktop is "gradle-jvm", which is wrong.
Please update the example, that other people can use it without any hassle.