### PR TITLE
Replace hardcoded kotlin groupId with KOTLIN_GROUP_ID

### DIFF
--- a/sources/frontend-api/src/org/jetbrains/amper/frontend/kotlin/CompilerPluginConfig.kt
+++ b/sources/frontend-api/src/org/jetbrains/amper/frontend/kotlin/CompilerPluginConfig.kt
@@ -140,7 +140,7 @@ data class LombokCompilerPluginConfig(val kotlinVersion: String) : CompilerPlugi
     override val id = "org.jetbrains.kotlin.lombok"
     override val options = emptyList<Option>()
     override val mavenCoordinates = CompilerPluginConfig.MavenCoordinates(
-        groupId = "org.jetbrains.kotlin",
+        groupId = KOTLIN_GROUP_ID,
         artifactId = "kotlin-lombok-compiler-plugin-embeddable",
         version = kotlinVersion,
     )


### PR DESCRIPTION
I know that it's a very small change..

But I want to be listed as a contributor to amper ;) Haha