### PR TITLE
Avoid deploying docs in forked repos

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-latest
-
+    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Skips jobs like https://github.com/Goooler/amper/actions/workflows/publish-docs.yml.