### PR TITLE
 Fix compiling projects that targets android native.

### DIFF
--- a/sources/frontend-api/src/org/jetbrains/amper/frontend/platform.kt
+++ b/sources/frontend-api/src/org/jetbrains/amper/frontend/platform.kt
@@ -86,8 +86,11 @@ enum class Platform(
      * * It should match the values of the `-target` argument of the Kotlin/Native compiler.
      * * It should match the names of the platforms in the .konan directory.
      */
-    val nameForCompiler: String
-        get() = name.lowercase()
+    val nameForCompiler: String 
+        get() = when {
+            isDescendantOf(ANDROID_NATIVE) -> name.replace("_native", "")
+            else -> name
+        }.lowercase()
 
     /**
      * Get leaf children of this parent if it is a parent; List of self otherwise.


### PR DESCRIPTION
`KonanTarget` does not add the `_native` suffix for android native targets.

https://github.com/JetBrains/kotlin/blob/master/native/utils/src/org/jetbrains/kotlin/konan/target/KonanTarget.kt#L16-L19

Here is what currently happens when you try to compile a project that targets android native.

```yaml
product:
  type: lib
  platforms: [androidNativeArm64]
```

logs
```
00:03.807 ERROR :project:compileAndroidNativeArm64Debug error: compilation failed: Unknown target: android_native_arm64. Use -list_targets to see the list of available targets
00:03.812 ERROR :project:compileAndroidNativeArm64Debug
00:03.814 ERROR :project:compileAndroidNativeArm64Debug  * Source files: World.kt
00:03.816 ERROR :project:compileAndroidNativeArm64Debug  * Compiler version: 2.3.20
00:03.819 ERROR :project:compileAndroidNativeArm64Debug  * Output kind: LIBRARY
00:03.821 ERROR :project:compileAndroidNativeArm64Debug
00:03.823 ERROR :project:compileAndroidNativeArm64Debug exception: org.jetbrains.kotlin.konan.target.TargetSupportException: Unknown target: android_native_arm64. Use -list_targets to see the list of available targets
00:03.825 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.konan.target.HostManager.known(HostManager.kt:41)
00:03.827 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.konan.target.TargetManagerImpl.determineCurrent(TargetManager.kt:32)
00:03.829 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.konan.target.TargetManagerImpl.<init>(TargetManager.kt:15)
00:03.832 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.konan.target.HostManager.targetManager(HostManager.kt:13)
00:03.834 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.backend.konan.KonanConfig.<init>(KonanConfig.kt:88)
00:03.836 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.backend.konan.KonanDriver.run(KonanDriver.kt:109)
00:03.838 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.bc.K2Native.runKonanDriver(K2Native.kt:179)
00:03.840 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:75)
00:03.842 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.bc.K2Native.doExecute(K2Native.kt:37)
00:03.845 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:125)
00:03.847 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:363)
00:03.849 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:341)
00:03.851 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:303)
00:03.853 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.common.CLICompiler$Companion.doMainNoExit(CLICompiler.kt:442)
00:03.857 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.common.CLICompiler$Companion.doMainNoExit$default(CLICompiler.kt:437)
00:03.858 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.common.CLICompiler$Companion.doMain(CLICompiler.kt:429)
00:03.860 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.bc.K2Native$Companion.main$lambda$0(K2Native.kt:215)
00:03.862 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.util.UtilKt.profileIf(Util.kt:22)
00:03.864 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.util.UtilKt.profile(Util.kt:16)
00:03.866 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.bc.K2Native$Companion.main(K2Native.kt:214)
00:03.867 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.bc.K2NativeKt.main(K2Native.kt:245)
00:03.870 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.utilities.MainKt$main$1.invoke(main.kt:40)
00:03.872 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.utilities.MainKt$main$1.invoke(main.kt:40)
00:03.874 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.utilities.MainKt.mainImpl(main.kt:20)
00:03.876 ERROR :project:compileAndroidNativeArm64Debug    at org.jetbrains.kotlin.cli.utilities.MainKt.main(main.kt:40)
00:03.877 ERROR :project:compileAndroidNativeArm64Debug

ERROR: Task ':project:compileAndroidNativeArm64Debug' failed: Kotlin native compilation failed:

error: compilation failed: Unknown target: android_native_arm64. Use -list_targets to see the list of available targets
exception: org.jetbrains.kotlin.konan.target.TargetSupportException: Unknown target: android_native_arm64. Use -list_targets to see the list of available targets
```